### PR TITLE
Convert 'string' variable to string 

### DIFF
--- a/src/PersianNumberWords.js
+++ b/src/PersianNumberWords.js
@@ -11,7 +11,7 @@ const numbers = {
 const delimiter = ' و ';
 
 function convert(input) {
-  let string = input;
+  let string = input + ''; // covert to string.
 
   string = string.split('')
     .reverse()


### PR DESCRIPTION
If you call convert function with a number it throws an error **TypeError: string.split is not a function**.
So converting `string` to string type will solve the problem.
